### PR TITLE
Show tags on posts

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -13,6 +13,14 @@ layout: default
       {%- if page.author -%}
         • <span itemprop="author" itemscope itemtype="http://schema.org/Person"><span class="p-author h-card" itemprop="name">{{ page.author }}</span></span>
       {%- endif -%}</p>
+      {% if page.tags.size > 0 %}
+      <div class="post-tags">
+        Tags:
+        {% for tag in page.tags %}
+          <a href="/tags/#{{- tag -}}">{{ tag }}</a>
+        {% endfor %}
+      </div>
+      {% endif %}
   </header>
 
   <div class="post-content e-content" itemprop="articleBody">

--- a/tags.html
+++ b/tags.html
@@ -1,0 +1,14 @@
+---
+layout: page
+title: Tags
+permalink: /tags/
+---
+
+{% for tag in site.tags %}
+  <h2 id="{{ tag[0] }}">{{ tag[0] }}</h2>
+  <ul>
+    {% for post in tag[1] %}
+      <li><a href="{{ post.url }}">{{ post.title }}</a></li>
+    {% endfor %}
+  </ul>
+{% endfor %}


### PR DESCRIPTION
Add a tags line before date+author line at the top of each post. Each tag is clickable to a page showing other articles with the same tag.