### PR TITLE
fix: migrate deprecated onBrokenMarkdownLinks config option

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -24,7 +24,12 @@ const config = {
   projectName: 'blog', // Usually your repo name.
 
   onBrokenLinks: 'throw',
-  onBrokenMarkdownLinks: 'warn',
+
+  markdown: {
+    hooks: {
+      onBrokenMarkdownLinks: 'warn',
+    },
+  },
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you


### PR DESCRIPTION
## Summary

- Move `onBrokenMarkdownLinks` from the top-level `siteConfig` to `siteConfig.markdown.hooks.onBrokenMarkdownLinks`, fixing the deprecation warning emitted by Docusaurus 3.10

## Test plan

- [x] `npm run build` succeeds with no deprecation warnings
