### PR TITLE
fix: add truncate markers to blog posts missing them

### DIFF
--- a/blog/2012-07-03-playcanvas-google-io.md
+++ b/blog/2012-07-03-playcanvas-google-io.md
@@ -8,6 +8,8 @@ tags:
 
 A massive thank you to everybody who took the time to swing by our stand at Google I/O last week. We had an amazing time and hope you did too. If you weren't at the conference, here's our space in the Developer Sandbox:
 
+<!-- truncate -->
+
 [![Google IO Booth](/img/google-io-booth.jpg)](/img/google-io-booth.jpg)
 
 We were really excited to be showing our latest game/demo: a networked multiplayer, third person shooter. We were running MacBook Pro and a ChromeBook connected to a node.js server. We think we did a great job of showing just what's possible with HTML5 (and WebGL) with only moderate hardware. Expect some more info soon on the near-term plans we have for the demo...

--- a/blog/2013-08-21-making-an-html5-game-pong.md
+++ b/blog/2013-08-21-making-an-html5-game-pong.md
@@ -8,6 +8,8 @@ tags:
 
 A video tutorial on how to make a Pong clone using PlayCanvas.
 
+<!-- truncate -->
+
 Will has put together a short video showing how you can make a Pong game using PlayCanvas. It will take you through creating Primitive shapes, how to use the built-in physics engine, and some gameplay scripting to move the player paddles. It's a great introduction to PlayCanvas and building games.
 
 Check it out on [YouTube](https://www.youtube.com/watch?v=oeR-flW-ojw) or below:

--- a/blog/2013-08-28-introduction-to-ammo-js.md
+++ b/blog/2013-08-28-introduction-to-ammo-js.md
@@ -9,6 +9,8 @@ tags:
 
 Last night I presented at the [London HTML5 Game Dev meetup](http://www.meetup.com/London-HTML5-Game-Developers/). As usual we had an awesome time and if you're based in or around London then you should definitely try and get along to the next one.
 
+<!-- truncate -->
+
 It was an overview of the ammo.js the physics engine we use internally for PlayCanvas and should be an interesting read for anyone who isn't totally familiar with what a physics engine is or does. It gives a nice overview of the different parts that make up a full physics engine and includes a bunch of demos about what is possible with PlayCanvas.
 
 [iframe src="http://slid.es/davee/introduction-to-ammojs/embed" width="576" height="420" scrolling="no" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen>]

--- a/blog/2013-09-09-making-an-html5-game-lunar-lander.md
+++ b/blog/2013-09-09-making-an-html5-game-lunar-lander.md
@@ -8,6 +8,8 @@ tags:
 
 A video tutorial recreating arcade classic, Lunar Lander in 3D.
 
+<!-- truncate -->
+
 This is our second video tutorial. It's a bit longer (around 45mins) but it covers a lot of stuff. Uploading 3D models, physics coding, collision events, input controllers, playing audio and publishing games to the web. It's a great introduction to lots of major features of PlayCanvas.
 
 <div className="iframe-container">

--- a/blog/2013-09-13-new-look-designer.md
+++ b/blog/2013-09-13-new-look-designer.md
@@ -8,6 +8,8 @@ tags:
 
 We've updated the Designer theme to give it an all-new Pro look.
 
+<!-- truncate -->
+
 [![New Designer Theme](/img/editor-extjs-dark.png)](/img/editor-extjs-dark.png)  
 _Black is the new Black_
 

--- a/blog/2013-09-19-see-your-friends.md
+++ b/blog/2013-09-19-see-your-friends.md
@@ -10,6 +10,8 @@ See what all your friends are looking at, as remote user cameras show up in the 
 
 The new features keep on coming from the PlayCanvas mines of awesome, and today's is a biggie.
 
+<!-- truncate -->
+
 <!-- [iframe class="vine-embed" src="https://vine.co/v/hvvxaZunntI/embed/simple"][/iframe] -->
 
 We're now displaying the camera's of all the users who are viewing your pack. Now it's really starting to feel like a collaborative process when you are building your game.

--- a/blog/2014-03-16-playcanvas-sxsw.md
+++ b/blog/2014-03-16-playcanvas-sxsw.md
@@ -11,4 +11,6 @@ _CEO Will Eastcott at SXSW Accelerator_
 
 This past week the PlayCanvas founders have been deep in the heart of Texas at the celebrated mega-festival SXSW. We were chosen from over 500 companies to pitch to a enormous room full of business leads, journalists and tech enthusiasts. Will was on stage and we wowed them successfully enough to get through the final 3. Sadly another talented start-up crew beat us to the No. 1 slot, but a close 2nd is still pretty damn good.
 
+<!-- truncate -->
+
 We've moved on from Austin now, and we're in San Francisco preparing plenty of exciting news and demos for the Game Developer Conference. We look forward to sharing lots more stuff with you this week!

--- a/blog/2014-06-04-ios-webgl-support.md
+++ b/blog/2014-06-04-ios-webgl-support.md
@@ -9,6 +9,8 @@ tags:
 
 [![PlayCanvas on iPhone](/img/playcanvas-ios.png)](/img/playcanvas-ios.png)
 
-Looks like [Will was right](https://blog.playcanvas.com/apple-embraces-webgl/) with his predictions for the Apple announcements at WWDC. Our friends at [Ludei](https://www.linkedin.com/company/ludei/about/) have confirmed that WebGL is supported on iOS devices.
+Looks like [Will was right](https://blog.playcanvas.com/apple-embraces-webgl/) with his predictions for the Apple announcements at WWDC. Our friends at [Ludei](https://www.linkedin.com/company/ludei/about/) have confirmed that WebGL is supported on iOS devices.
+
+<!-- truncate -->
 
 This is great news for PlayCanvas users who can now deploy games to every major browser, whether mobile or desktop.

--- a/blog/2016-01-30-tutorial-series-a-complete-playcanvas-game.md
+++ b/blog/2016-01-30-tutorial-series-a-complete-playcanvas-game.md
@@ -8,6 +8,8 @@ tags:
 
 [![Keepy Up](/img/keepy-up.jpg)](https://developer.playcanvas.com/tutorials/keepyup-part-one/)
 
-In preparation for your [PLAYHACK game jam](https://blog.playcanvas.com/playhack-with-playjam-starts-on-monday/), why not run through our [6 part tutorial](https://developer.playcanvas.com/tutorials/keepyup-part-one/) that takes you through building a complete game in PlayCanvas?
+In preparation for your [PLAYHACK game jam](https://blog.playcanvas.com/playhack-with-playjam-starts-on-monday/), why not run through our [6 part tutorial](https://developer.playcanvas.com/tutorials/keepyup-part-one/) that takes you through building a complete game in PlayCanvas?
 
-The six parts cover: Scene setup, Materials, Scripting, Audio and Particle effects and User Interface.
+<!-- truncate -->
+
+The six parts cover: Scene setup, Materials, Scripting, Audio and Particle effects and User Interface.

--- a/blog/2017-06-09-maintenance-saturday-june-10-9am-utc.md
+++ b/blog/2017-06-09-maintenance-saturday-june-10-9am-utc.md
@@ -9,6 +9,8 @@ tags:
 
 The PlayCanvas website and editor will be unavailable intermittently from 9am UTC tomorrow (Saturday 10th June) while we perform server maintenance. We will endeavor to keep downtime to a minimum but the period of downtime may be several hours. Stay informed with updates via this blog post and on our [Twitter Account](https://twitter.com/playcanvas).
 
+<!-- truncate -->
+
 We apologies for any inconvenience this may cause.
 
 Update: Maintenance is complete at 2.30pm UTC. Thanks for you patience.


### PR DESCRIPTION
## Summary

- Add `<!-- truncate -->` markers to the 10 blog posts that were missing them, eliminating the Docusaurus build warning about untruncated blog posts

### Posts updated

- `2012-07-03-playcanvas-google-io.md`
- `2013-08-21-making-an-html5-game-pong.md`
- `2013-08-28-introduction-to-ammo-js.md`
- `2013-09-09-making-an-html5-game-lunar-lander.md`
- `2013-09-13-new-look-designer.md`
- `2013-09-19-see-your-friends.md`
- `2014-03-16-playcanvas-sxsw.md`
- `2014-06-04-ios-webgl-support.md`
- `2016-01-30-tutorial-series-a-complete-playcanvas-game.md`
- `2017-06-09-maintenance-saturday-june-10-9am-utc.md`

## Test plan

- [x] `npm run build` succeeds with no truncation warnings
- [x] `npm run lint` passes with 0 errors
