### PR TITLE
chore: remove babel config (superseded by SWC)

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,0 @@
-module.exports = {
-  presets: [require.resolve('@docusaurus/core/lib/babel/preset')],
-};


### PR DESCRIPTION
## Summary

- Remove `babel.config.js` since the site now uses SWC via Docusaurus Faster, making the Babel config unnecessary

## Test plan

- [x] `npm run build` succeeds with no Babel warning
