### PR TITLE
fix: resolve nested anchor tag warnings in two blog posts

### DIFF
--- a/blog/2020-07-21-plan-updates-more-storage-more-features-same-price.md
+++ b/blog/2020-07-21-plan-updates-more-storage-more-features-same-price.md
@@ -33,6 +33,4 @@ Best of all, this comes at **no extra cost**! 🎉🎉🎉
 
 If you're new to PlayCanvas, now is the perfect time to get started! We hope you enjoy these new features and updates.
 
-One last thing! We are super-excited to spread the word - can you help us with a retweet?  
-
-<blockquote class="twitter-tweet"><p lang="en" dir="ltr">HUGE announcement! We&#39;re giving you more! Much more:<br /><br />✅ 5-10X Storage<br />✅ Download your apps for self-hosting<br />✅ Customize PlayCanvas loading screen<br />✅ Archive your projects offline<a href="https://t.co/78jf9U3YkM">https://t.co/78jf9U3YkM</a><br /><br />Get started with <a href="https://twitter.com/hashtag/gamedev?src=hash&amp;ref_src=twsrc%5Etfw">#gamedev</a> today!</p>&mdash; PlayCanvas (@playcanvas) <a href="https://twitter.com/playcanvas/status/1285598408787582977?ref_src=twsrc%5Etfw">July 21, 2020</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+One last thing! We are super-excited to spread the word - can you help us with a repost on [X](https://x.com/playcanvas/status/1285598408787582977)?

--- a/blog/2025-02-13-publish-your-gaussian-splats-with-supersplat.md
+++ b/blog/2025-02-13-publish-your-gaussian-splats-with-supersplat.md
@@ -21,7 +21,7 @@ SuperSplat can now be found on a shiny new domain! From now on, point your brows
 
 <div style={{ textAlign: 'center' }}>
   <a href="https://superspl.at" style={{ fontSize: '2rem', fontWeight: 'bold', textDecoration: 'none' }}>
-    https://superspl.at
+    superspl.at
   </a>
 </div>
 


### PR DESCRIPTION
## Summary

- Fix nested `<a>` tag warnings flagged by the HTML minifier during build
- **publish-your-gaussian-splats-with-supersplat**: Change link text from `https://superspl.at` to `superspl.at` to prevent MDX auto-linking inside the existing anchor
- **plan-updates-more-storage-more-features-same-price**: Replace broken Twitter embed (widget.js no longer works) with a simple link to the post on X

## Test plan

- [x] `npm run build` succeeds with zero warnings
- [x] `npm run lint` passes with 0 errors
