### PR TITLE
Clarify Chart.js import catch comment in GSplatPerfChart

### DIFF
--- a/src/components/GSplatPerfChart/index.jsx
+++ b/src/components/GSplatPerfChart/index.jsx
@@ -102,8 +102,8 @@ export default function GSplatPerfChart({ device = 'desktop' }) {
         }
       });
     }).catch((err) => {
-      // Chunk failed to load (network error, blocked script, etc.) — fail quietly
-      // rather than surfacing an unhandled promise rejection.
+      // Chunk failed to load (network error, blocked script, etc.) — log it and
+      // swallow the rejection so it doesn't surface as an unhandled promise rejection.
       console.error('Failed to load Chart.js for GSplatPerfChart:', err);
     });
 


### PR DESCRIPTION
## What

Follow-up to #72 addressing a post-merge Copilot review comment on `GSplatPerfChart`.

The `.catch()` handler for the dynamic `import('chart.js/auto')` had a comment describing the failure as handled "quietly", but the handler logs via `console.error` — a contradiction. This rewords the comment to match the actual behavior (log the error and swallow the rejection so it doesn't surface as an unhandled promise rejection). No behavior change.

## Why

Keeps the code comment accurate; `console.error` is appropriate here since a failed Chart.js load means the chart genuinely won't render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
