### PR TITLE
Add Gaussian splatting docs CTA to June 2026 SuperSplat post

### DIFF
--- a/blog/2026-06-03-new-in-supersplat-webgpu-and-streaming-bring-huge-performance-wins.md
+++ b/blog/2026-06-03-new-in-supersplat-webgpu-and-streaming-bring-huge-performance-wins.md
@@ -66,6 +66,8 @@ If you're building a splat-based application, we'd love for you to build it on P
 - [SuperSplat Viewer](https://github.com/playcanvas/supersplat-viewer)
 - [SplatTransform](https://github.com/playcanvas/splat-transform)
 
+New to Gaussian splatting on PlayCanvas? Our [Gaussian Splatting documentation](https://developer.playcanvas.com/user-manual/gaussian-splatting/) is the best place to get started.
+
 ### 👂 We Want to Hear from You
 
 What do you think of the new features? What would you like to see next? Come and join us on the [PlayCanvas Discord](https://discord.com/invite/T3pnhRTTAY) — it's where the world's best splat creators hang out and we'd love to have you there.


### PR DESCRIPTION
## What

Adds a "get started" CTA to the merged June 2026 "New in SuperSplat" post (follow-up to #72).

In the **Free and Open Source** section, after the GitHub repo list, it links the PlayCanvas Gaussian Splatting user-manual docs:

> New to Gaussian splatting on PlayCanvas? Our [Gaussian Splatting documentation](https://developer.playcanvas.com/user-manual/gaussian-splatting/) is the best place to get started.

## Why

Gives readers who are new to splatting a clear next step, complementing the existing repo links and Discord CTA.

## Verification

`npm run build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
