### PR TITLE
Publish June 2026 SuperSplat post (remove unlisted flag)

### DIFF
--- a/blog/2026-06-03-new-in-supersplat-webgpu-and-streaming-bring-huge-performance-wins.md
+++ b/blog/2026-06-03-new-in-supersplat-webgpu-and-streaming-bring-huge-performance-wins.md
@@ -2,7 +2,6 @@
 authors: will
 slug: new-in-supersplat-webgpu-and-streaming-bring-huge-performance-wins
 title: "New in SuperSplat: WebGPU and Streaming Bring Huge Performance Wins"
-unlisted: true
 tags:
   - gaussian-splats
   - supersplat


### PR DESCRIPTION
## What

Publishes the June 2026 "New in SuperSplat" post by removing `unlisted: true` from its front matter.

The post was intentionally merged unlisted (#72) so it could be previewed by direct URL ahead of the announcement. Removing the flag now makes it appear in the blog index, tag pages, sitemap and RSS feed.

## Verification

`npm run build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
