### PR TITLE
Post-publish copy tweaks: intro wording + splat credit

### DIFF
--- a/blog/2026-07-09-new-in-supersplat-vibe-code-splat-apps.md
+++ b/blog/2026-07-09-new-in-supersplat-vibe-code-splat-apps.md
@@ -12,7 +12,7 @@ tags:
 
 import AppEmbed from '@site/src/components/AppEmbed';
 
-Last month we shipped **[WebGPU and Streaming Bring Huge Performance Wins](/new-in-supersplat-webgpu-and-streaming-bring-huge-performance-wins)** — a huge leap in how fast splats load and render. Today's update is all about what you can *do* with your splats. We're rolling out a way to **vibe code an entire app around any splat**, plus **360° video rendering** and **SPZ export** in SuperSplat Editor 2.29.0, and a major new release of **splat-transform**.
+Last month we shipped **[a new WebGPU renderer and automatic streaming](/new-in-supersplat-webgpu-and-streaming-bring-huge-performance-wins)** — a huge leap in how fast splats load and render. Today's update is all about what you can *do* with your splats. We're rolling out a way to **vibe code an entire app around any splat**, plus **360° video rendering** and **SPZ export** in SuperSplat Editor 2.29.0, and a major new release of **splat-transform**.
 
 <!-- truncate -->
 

--- a/blog/2026-07-09-new-in-supersplat-vibe-code-splat-apps.md
+++ b/blog/2026-07-09-new-in-supersplat-vibe-code-splat-apps.md
@@ -26,7 +26,7 @@ Open any downloadable scene, hit **Download** and choose the **Vite project** op
 
 Here's the fun part. The project is deliberately **minimal and fully typed**: the viewer logic lives in a single `src/main.ts`, and everything you'd want to change sits in one clearly named `src/splat-config.ts`. That makes it the perfect thing to hand to your favorite AI coding assistant — Cursor, Claude Code, whatever you like — and **vibe code** the app you actually want. Add hotspots, build a product configurator, drop in a character controller… it's the fastest path we've found from a raw scan to a shippable web app.
 
-Here's one we vibe-coded earlier: an interactive **snow globe** built from a single splat of Le Mont Saint-Michel. Hit play to launch the live app — it's a hefty splat, so it only loads when you ask:
+Here's one we vibe-coded earlier: an interactive **snow globe** built from a single [Le Mont Saint-Michel splat](https://superspl.at/scene/7e1bd643) by Mykhailo Moroz. Hit play to launch the live app — it's a hefty splat, so it only loads when you ask:
 
 <AppEmbed
   src="https://willeastcott.github.io/snowglobe/"


### PR DESCRIPTION
Two small copy tweaks to the (now-live) July 2026 **New in SuperSplat** post.

### 1. Intro reads more naturally
The opening dropped the previous post's full, sentence-style title straight after "we shipped". Reworded to a natural phrase (same link target):

> Last month we shipped **a new WebGPU renderer and automatic streaming** — a huge leap in how fast splats load and render.

### 2. Credit the splat
Credit and link the **Le Mont Saint-Michel** splat by **Mykhailo Moroz** (https://superspl.at/scene/7e1bd643), used in the vibe-coding screencast and the Snow Globe app.

`docusaurus build` passes; markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)