### PR TITLE
Trim SPZ sentence in SuperSplat post

### DIFF
--- a/blog/2026-07-09-new-in-supersplat-vibe-code-splat-apps.md
+++ b/blog/2026-07-09-new-in-supersplat-vibe-code-splat-apps.md
@@ -53,7 +53,7 @@ And we didn't stop at video. SuperSplat can now also export **360° equirectangu
 
 ### 📦 SPZ Export
 
-SuperSplat Editor 2.29.0 also adds export to **SPZ**, the open, compressed splat format created by Niantic Labs for Scaniverse. SPZ files are roughly **10× smaller than the equivalent PLY** with virtually no perceptible loss in quality, and the format has quickly become a common language for moving splats between tools.
+SuperSplat Editor 2.29.0 also adds export to **SPZ**, the open, compressed splat format created by Niantic Labs for Scaniverse. SPZ files are roughly **10× smaller than the equivalent PLY** with virtually no perceptible loss in quality.
 
 With SPZ export, your SuperSplat scenes drop straight into Scaniverse and any other SPZ‑compatible app or pipeline.
 


### PR DESCRIPTION
Small copy tweak to the live July 2026 **New in SuperSplat** post.

Drops the trailing clause from the SPZ sentence so it ends on the size/quality point:

> SPZ files are roughly **10× smaller than the equivalent PLY** with virtually no perceptible loss in quality.

(Removed: "…, and the format has quickly become a common language for moving splats between tools.")

`docusaurus build` passes; markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)