### PR TITLE
Add playsInline to all video embeds to fix iOS fullscreen hijack

### DIFF
--- a/blog/2016-10-24-miniclip-launches-their-first-playcanvas-game.md
+++ b/blog/2016-10-24-miniclip-launches-their-first-playcanvas-game.md
@@ -9,7 +9,7 @@ tags:
 
 PlayCanvas is proud to announce that browser-gaming giant Miniclip has published their first PlayCanvas-powered game: Virtual Voodoo.
 
-<video autoPlay muted loop controls src='/img/virtualvoodoo.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/virtualvoodoo.mp4' style={{width: '100%', height: 'auto'}} />
 
 <!-- truncate -->
 

--- a/blog/2016-11-11-refinements-aplenty-for-our-webgl-editor.md
+++ b/blog/2016-11-11-refinements-aplenty-for-our-webgl-editor.md
@@ -20,7 +20,7 @@ We've added a button to the top right of the Inspector panel that allows you to 
 
 We have updated PlayCanvas' build of Ammo.js to the very latest version. This update benefits from 2 years of Emscripten improvements and exposes much more of the Bullet API. So if you are feeling adventurous, you can delve into the parts of Ammo that PlayCanvas does not expose and try some more advanced physics effects. For example, soft body physics. Or maybe utilize constraints for things like ragdolls, as shown below:
 
-<video autoPlay muted loop controls src='/img/ragdoll.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/ragdoll.mp4' style={{width: '100%', height: 'auto'}} />
 
 Want to check out the project above? It's [here](https://playcanvas.com/project/431888/overview/ragdoll).
 

--- a/blog/2016-11-21-playcanvas-interviewed-live-on-bbc-news.md
+++ b/blog/2016-11-21-playcanvas-interviewed-live-on-bbc-news.md
@@ -6,7 +6,7 @@ title: PlayCanvas Interviewed Live on BBC News
 
 On Friday, 18th November, PlayCanvas HQ was visited by BBC News, the world's largest broadcast news organization. Our CEO Will was interviewed live on the 6 o'clock evening news which has viewing figures of around 1 million people.
 
-<video controls src='/img/BBC-London-Evening-News-18_11_2016.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline controls src='/img/BBC-London-Evening-News-18_11_2016.mp4' style={{width: '100%', height: 'auto'}} />
 
 <!-- truncate -->
 

--- a/blog/2016-12-20-disney-selects-playcanvas-for-hour-of-code.md
+++ b/blog/2016-12-20-disney-selects-playcanvas-for-hour-of-code.md
@@ -6,7 +6,7 @@ title: Disney Selects PlayCanvas for Hour of Code
 
 We're proud to announce that Disney has selected PlayCanvas to power their newly launched Hour of Code application. Entitled "Moana: Wayfinding with Code", it's a free online tutorial to teach kids the basics of computer science.
 
-<video autoPlay muted loop controls src='/img/moana-hour-of-code.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/moana-hour-of-code.mp4' style={{width: '100%', height: 'auto'}} />
 
 <!-- truncate -->
 

--- a/blog/2017-01-03-playcanvas-in-2016-webgl-everywhere.md
+++ b/blog/2017-01-03-playcanvas-in-2016-webgl-everywhere.md
@@ -14,13 +14,13 @@ The last twelve months have seen some incredible companies adopt PlayCanvas. Her
 
 **Disney** selected PlayCanvas for the [Moana-themed Hour of Code](http://partners.disney.com/hour-of-code)
 
-<video autoPlay muted loop controls src='/img/moana-hour-of-code.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/moana-hour-of-code.mp4' style={{width: '100%', height: 'auto'}} />
 
 **King** published [Shuffle Cats Mini](https://www.facebook.com/ShuffleCatsMini/) as a launch title for Facebook Instant Games
 
 **Miniclip** published the fiendish [Virtual Voodoo](http://www.miniclip.com/games/virtual-voodoo/en/) on their portal:
 
-<video autoPlay muted loop controls src='/img/virtualvoodoo.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/virtualvoodoo.mp4' style={{width: '100%', height: 'auto'}} />
 
 **Leapfrog** launched the [Leapfrog Academy](https://store.leapfrog.com/en-gb/academy/landing) subscription service
 
@@ -60,10 +60,10 @@ Here are our top 5 picks for PlayCanvas tech improvements during 2016:
 
 Plenty of PlayCanvas games have been released during 2016 but we have to give special mention to Midgard's [BlastArena](http://blastarena.io)! It pays homage to the classic Bomberman with frenetic, insanely fun online play.
 
-<video autoPlay muted loop controls src='/img/blastarena.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/blastarena.mp4' style={{width: '100%', height: 'auto'}} />
 
 And we have to give special mention to our own online multiplayer game [TANX](https://tanx.io)! 2016 saw the game receive a massive upgrade, with stunning new visuals and level design.
 
-<video autoPlay muted loop controls src='/img/tanx.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/tanx.mp4' style={{width: '100%', height: 'auto'}} />
 
 PlayCanvas continues to race ahead as the leading platform for building lightweight, mobile-friendly WebGL content. We've got lots of surprises in store for 2017 and we can't wait to share them with you. Happy New Year everyone!

--- a/blog/2021-05-05-introducing-the-anim-state-graph.md
+++ b/blog/2021-05-05-introducing-the-anim-state-graph.md
@@ -49,13 +49,13 @@ While these two characters use different animations for their various actions, t
 
 When opening an Anim State Graph asset you’ll be presented with a visual graph editor which allows you to define all of the different animation states your game object can be in. You can then connect these states using transitions.
 
-<video autoPlay muted loop controls src='/img/anim-create-state-graph.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/anim-create-state-graph.mp4' style={{width: '100%', height: 'auto'}} />
 
 _Create anim state graphs using the editor UI_
 
 Each transition blends between two animations over a specified amount of time. You can adjust and tweak transitions to your liking and see the results in real time in the PlayCanvas launch page. You can then assign parameter conditions to each transition to define the circumstances under which that transition can fire. These parameter values can be modified in your scripts to control the behavior of your animation system.
 
-<video autoPlay muted loop controls src='/img/anim-script-trigger.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/anim-script-trigger.mp4' style={{width: '100%', height: 'auto'}} />
 
 _Control anim state graph behavior in scripts using the anim component API_
 

--- a/blog/2021-11-08-anim-layer-masks-and-blending.md
+++ b/blog/2021-11-08-anim-layer-masks-and-blending.md
@@ -23,7 +23,7 @@ When creating complex animation behavior for games, it is often necessary to mak
 
 To perform these actions at the same time, the upper and lower body of the character must be animated independently. The upper body should be able to move from an idle stance to a shooting stance, and then shoot on demand, all while the lower body moves between idling, walking, running based on the player's command.
 
-<video autoPlay muted loop controls src='/img/anim-masked-locomotion.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/anim-masked-locomotion.mp4' style={{width: '100%', height: 'auto'}} />
 
 _A character with two animation layers. A movement layer and a shooting layer masked to the upper body_
 
@@ -35,7 +35,7 @@ A shooting animation might have all of its lower body bones removed, which would
 
 Masks can streamline this workflow by enabling developers to add or remove a model’s bones from an animation layer directly. This means you can select which part of a character a particular set of animations should animate directly in the PlayCanvas editor. Testing out different combinations of character bones now becomes as simple as toggling a few checkboxes.
 
-<video autoPlay muted loop controls src='/img/anim-layer-masking.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/anim-layer-masking.mp4' style={{width: '100%', height: 'auto'}} />
 
 _Creating layer masks in the PlayCanvas editor_
 

--- a/blog/2022-01-04-playcanvas-review-of-2021.md
+++ b/blog/2022-01-04-playcanvas-review-of-2021.md
@@ -32,13 +32,13 @@ With all of the front-end updates to the Editor, don't think that we have neglec
 
 Aside from the Editor, one of the coolest new tools we released this year was the [Engine Examples Browser](https://playcanvas.github.io/). This is a coding playground for learning and experimenting with the PlayCanvas Engine API. And naturally, it's fully open sourced on [GitHub](https://github.com/playcanvas/engine/tree/dev/examples#readme).
 
-<video autoPlay muted loop controls src='/img/examples-browser.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/examples-browser.mp4' style={{width: '100%', height: 'auto'}} />
 
 _Engine Examples Browser_
 
 Back in the summer, we [announced](https://forum.playcanvas.com/t/rfc-shader-editor/20616) our new Node-based Shader Editor. This is a new and accessible way to build custom shaders for your PlayCanvas application.
 
-<video autoPlay muted loop controls src='/img/shader-editor.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/shader-editor.mp4' style={{width: '100%', height: 'auto'}} />
 
 _Node-based Shader Editor_
 
@@ -46,7 +46,7 @@ We're nearing the end of the closed beta and in the coming months, we will kick 
 
 The [PlayCanvas Viewer](https://playcanvas.com/viewer) is our open source 3D model viewer tool. In 2021, it received a number of important improvements. First up, as well as glTF files, the viewer can now also load VOX files (for voxel based scenes constructed in tools like MagicaVoxel). We also improved skeletal visualization as well as skybox handling. Check it out on [GitHub](https://github.com/playcanvas/playcanvas-viewer)!
 
-<video autoPlay muted loop controls src='/img/gltf-viewer-vox.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/gltf-viewer-vox.mp4' style={{width: '100%', height: 'auto'}} />
 
 _PlayCanvas glTF Viewer_
 
@@ -54,7 +54,7 @@ _PlayCanvas glTF Viewer_
 
 Let's be honest - everybody loves beautifully rendered pixels. So let's examine how PlayCanvas' graphics engine has advanced this year. First up, we have area lights that allow lights to adopt a physical shape: rectangle, circle or sphere. Later in the year, we released a preview or our new clustered lighting pipeline, which essentially increases the number of dynamic lights you can place in your scenes. With both features combined, the engine can now process clustered area lights as our [new engine example](https://playcanvas.github.io/#/graphics/clustered-area-lights) demonstrates.
 
-<video autoPlay muted loop controls src='/img/engine-clustered-area-lights.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/engine-clustered-area-lights.mp4' style={{width: '100%', height: 'auto'}} />
 
 _Clustered Area Lights_
 

--- a/blog/2022-10-27-webar-experiences-developer-spotlight-with-animech.md
+++ b/blog/2022-10-27-webar-experiences-developer-spotlight-with-animech.md
@@ -28,7 +28,7 @@ We have also visualized experiences for hotel safes, medical instruments and lab
 
 [Our core business is real-time 3D](https://www.animech.com/en/articles/3d-rendering-in-realtime). We push the boundaries every day trying to invent new ways of using 3D, where our solution makes the difference.
 
-<video autoPlay muted loop controls src='/img/animech-bathroom.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/animech-bathroom.mp4' style={{width: '100%', height: 'auto'}} />
 
 _[Bathroom Planner](https://www.inr.se/planera-badrum/planera-badrum-verktyg-3d/) for Iconic Nordic Rooms_
 
@@ -95,7 +95,7 @@ As the graphics quality gets better and better online and the fashion industry k
 
 Animech helps our customers to get what they want. Simply put: we empower people to make smart decisions through intelligent visualization.
 
-<video autoPlay muted loop controls src='/img/animech-cytiva.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/animech-cytiva.mp4' style={{width: '100%', height: 'auto'}} />
 
 **Thank you, Staffan! Is there anything else you'd like to share?**
 

--- a/blog/2023-02-07-how-to-make-your-html5-games-awesome.md
+++ b/blog/2023-02-07-how-to-make-your-html5-games-awesome.md
@@ -20,13 +20,13 @@ We'll use [Space Rocks!](https://playcanvas.com/project/1029772/overview/space-r
 
 Particularly, we'll explore how game polish can be achieved through **game juice**.
 
-<video autoPlay muted loop controls src='/img/Space-Rocks-before-and-after-v2-60fps.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/Space-Rocks-before-and-after-v2-60fps.mp4' style={{width: '100%', height: 'auto'}} />
 
 [Play it here!](https://playcanvas.com/project/1014332/overview/space-rocks)
 
 ## How it started
 
-<video autoPlay muted loop controls src='/img/Space-Rocks-How-it-started-1.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/Space-Rocks-How-it-started-1.mp4' style={{width: '100%', height: 'auto'}} />
 
 This was our starting point before we added game juice. While the game is fully functional and plays well, it lacks the visual and audio effects that would make it truly engaging. As a result, it feels a bit dull and uninteresting.
 
@@ -271,7 +271,7 @@ AmbientManager.prototype.updateTransition = function (transitionProgress) {
 
 Here's the end result with all of our asteroid changes:
 
-<video autoPlay muted loop controls src='/img/Space-Rocks-After.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/Space-Rocks-After.mp4' style={{width: '100%', height: 'auto'}} />
 
 It looks amazingly better! Already a massive difference from our starting point.
 
@@ -350,7 +350,7 @@ Lastly, let's add a small shockwave whenever we get hit! Let's use a particle sy
 
 The combined effects look like this:
 
-<video autoPlay muted loop controls src='/img/Space-Rocks-Preview.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/Space-Rocks-Preview.mp4' style={{width: '100%', height: 'auto'}} />
 
 You'll notice I've added screen shake to more than just the player getting hit! I'm a big fan of this effect, so I've added it to asteroid explosions and firing bullets as well!
 

--- a/blog/2024-05-22-a-faster-supersplat-with-pwa-support.md
+++ b/blog/2024-05-22-a-faster-supersplat-with-pwa-support.md
@@ -33,7 +33,7 @@ A Progressive Web App (PWA) is a web application that provides a native app-like
 
 From today, SuperSplat is shipping with PWA support! 🎉
 
-<video autoPlay muted loop controls src='/img/supersplat-pwa-install.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/supersplat-pwa-install.mp4' style={{width: '100%', height: 'auto'}} />
 
 To install SuperSplat as a PWA:
 
@@ -48,7 +48,7 @@ For your convenience, pin SuperSplat to the Taskbar (Windows) or add it do the D
 
 With SuperSplat installed as a PWA, your operating system can now open launch PLY files directly into the tool. Simply right-click on a PLY file and select SuperSplat to open it.
 
-<video autoPlay muted loop controls src='/img/supersplat-pwa-file-association.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/supersplat-pwa-file-association.mp4' style={{width: '100%', height: 'auto'}} />
 
 You can also set SuperSplat as the default tool to open your PLYs. Then, you can simply double-click a PLY file to open it instantly in SuperSplat!
 

--- a/blog/2024-06-05-create-3d-gaussian-splat-apps-with-the-playcanvas-editor.md
+++ b/blog/2024-06-05-create-3d-gaussian-splat-apps-with-the-playcanvas-editor.md
@@ -29,7 +29,7 @@ The application above shows several splats assembled in a single application, wi
 
 After [capturing the statues](https://developer.playcanvas.com/user-manual/graphics/gaussian-splatting/#creating-splats) to PLY format, our first stop is [SuperSplat](https://playcanvas.com/supersplat/editor?load=https://raw.githubusercontent.com/willeastcott/assets/main/statues/narcissus.compressed.ply), the open source tool for editing and optimizing 3D Gaussian Splats. Here, in a little over a minute, we can isolate the statue from the background and align it with the origin:
 
-<video autoPlay muted loop controls src='/img/statue-supersplat.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/statue-supersplat.mp4' style={{width: '100%', height: 'auto'}} />
 
 Once we are done, we can download the splat using our [compressed PLY format](https://blog.playcanvas.com/compressing-gaussian-splats). In this case, our downloaded PLY is **only 1.56MB**!
 
@@ -37,7 +37,7 @@ Once we are done, we can download the splat using our [compressed PLY format](ht
 
 Now that we have a clean, compressed PLY, we simply need to drop it into the Editor's Asset Panel. And from there, drag it into the viewport to add it to the scene. Let's do that (along with a cube map for a photographic backdrop):
 
-<video autoPlay muted loop controls src='/img/statue-editor.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/statue-editor.mp4' style={{width: '100%', height: 'auto'}} />
 
 The PlayCanvas Editor is a powerful visual environment for building and publishing 3D scenes. You can:
 
@@ -49,7 +49,7 @@ The PlayCanvas Editor is a powerful visual environment for building and publishi
 
 What really makes the demo pop is the transitions that fade the statues in and out.
 
-<video autoPlay muted loop controls src='/img/statue-custom-shaders.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/statue-custom-shaders.mp4' style={{width: '100%', height: 'auto'}} />
 
 With the Editor, you can customize the shader code that renders your splats to apply stunning animation effects. For the transition between statues, individual splats are transformed and recolored over time, while a full-screen bloom effect is ramped up and down.
 

--- a/blog/2025-02-13-publish-your-gaussian-splats-with-supersplat.md
+++ b/blog/2025-02-13-publish-your-gaussian-splats-with-supersplat.md
@@ -31,7 +31,7 @@ The SuperSplat Editor that you know and love can now be accessed at [https://sup
 
 Recently, we added the ability to export an HTML viewer of your splat from the SuperSplat Editor. Built on the powerful [PlayCanvas Engine](https://github.com/playcanvas/engine) and our open source [Compressed PLY format](/compressing-gaussian-splats#compressed-ply-format), it offers fast load times and high-performance rendering. However, _hosting_ the HTML viewer was still your responsibility. And let's be honest, not everybody has the time or expertise to host their own website. So we've added a new feature to SuperSplat to make it easier to share your splats with others.
 
-<video autoPlay muted loop controls src='/img/supersplat2-publish-1080p-social-60fps.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/supersplat2-publish-1080p-social-60fps.mp4' style={{width: '100%', height: 'auto'}} />
 
 It's as easy as 1-2-3:
 
@@ -49,7 +49,7 @@ By default, your splat will be listed on the SuperSplat website. However, you ca
 
 Sure, it's great to be able to share your splats with others, but for that extra 'wow' factor, why not add a camera flythrough? SuperSplat Editor 2.0 introduces the Timeline that makes it a breeze to author great looking camera animations. Simply select a frame in the timeline, position the camera, and set a keyframe. Do this for as many frames as you want and you've got a camera flythrough!
 
-<video autoPlay muted loop controls src='/img/supersplat2-camera-animation-720p-social-60fps.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/supersplat2-camera-animation-720p-social-60fps.mp4' style={{width: '100%', height: 'auto'}} />
 
 ### 📄 Load and Save your SuperSplat Projects
 
@@ -73,11 +73,11 @@ With the ability to publish splats to the web, [superspl.at](https://superspl.at
 
 One of the coolest things about the PlayCanvas-powered web viewer is that it's fully integrated with WebXR, the browser-based standard for immersive experiences. Simply tap the viewer's AR button and you can spawn photorealistic 3D models directly into your environment.
 
-<video autoPlay muted loop controls src='/img/supersplat2-ar-quest3.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/supersplat2-ar-quest3.mp4' style={{width: '100%', height: 'auto'}} />
 
 Or dive straight into a splat in fully immersive VR.
 
-<video autoPlay muted loop controls src='/img/supersplat2-vr-avp.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/supersplat2-vr-avp.mp4' style={{width: '100%', height: 'auto'}} />
 
 :::info
 🤳 AR mode has been tested on Meta Quest 2 and 3, and Android-based smartphones.  

--- a/blog/2025-03-13-render-your-gaussian-splats-to-video-with-supersplat.md
+++ b/blog/2025-03-13-render-your-gaussian-splats-to-video-with-supersplat.md
@@ -45,13 +45,13 @@ Here are some other awesome user pages for you to visit:
 
 You can now leave your thoughts or ask questions under any splat!
 
-<video autoPlay muted loop controls src='/img/supersplat-comments.mp4' style={{width: '50%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/supersplat-comments.mp4' style={{width: '50%', height: 'auto'}} />
 
 #### 🔄 Social Sharing
 
 You can easily share any splat to your favorite social channels: X, LinkedIn, Slack, email...you name it!
 
-<video autoPlay muted loop controls src='/img/supersplat-sharing.mp4' style={{width: '50%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/supersplat-sharing.mp4' style={{width: '50%', height: 'auto'}} />
 
 ### 🔗 Splat Embeds
 
@@ -67,7 +67,7 @@ To create an embed:
 * Copy the HTML code
 * Insert it at the appropriate place on your own site
 
-<video autoPlay muted loop controls src='/img/supersplat-embed.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/supersplat-embed.mp4' style={{width: '100%', height: 'auto'}} />
 
 ### 📺 Viewer Enhancements
 

--- a/blog/2025-06-10-esm-scripts-are-here.md
+++ b/blog/2025-06-10-esm-scripts-are-here.md
@@ -17,7 +17,7 @@ If you’ve ever struggled with managing classic scripts, wondered why your auto
 
 ESM (ECMAScript Modules) brings modern JavaScript development to the heart of PlayCanvas. It’s faster to get started, easier to scale your project, and way more fun to work with. No more hidden globals. No more messy script loading order. Just well-structured, maintainable, and modular code — exactly how modern web development should be.
 
-<video autoPlay muted loop controls src='/img/pc-esm-scripts.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/pc-esm-scripts.mp4' style={{width: '100%', height: 'auto'}} />
 
 <!-- truncate -->
 

--- a/blog/2025-07-15-splat-transform-launch.md
+++ b/blog/2025-07-15-splat-transform-launch.md
@@ -12,7 +12,7 @@ tags:
 
 **We're thrilled to announce the release of SplatTransform — a powerful CLI tool that makes working with 3D Gaussian Splats a breeze!**
 
-<video autoPlay muted loop controls src='/img/splat-transform.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/splat-transform.mp4' style={{width: '100%', height: 'auto'}} />
 
 :::note Open Source
 SplatTransform is [open-sourced under an MIT license on GitHub](https://github.com/playcanvas/splat-transform)

--- a/blog/2025-08-21-gaussian-splatting-for-e-commerce-developer-spotlight-on-reflct.md
+++ b/blog/2025-08-21-gaussian-splatting-for-e-commerce-developer-spotlight-on-reflct.md
@@ -73,7 +73,7 @@ You just do that a few times to set all the points in your scene where you want 
 
 When this is integrated with Shopify, the end user is able to explore a ‘shoppable’ 3DGS environment. Each time they move to a new product, the product details are displayed in the application. It’s quite exciting \- we haven’t seen that type of e-commerce experience before. We’re working with a few different brands here in New Zealand to take this to the next level.
 
-<video autoPlay muted loop controls src='/img/developer-spotlight-reflct-shopify-app.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/developer-spotlight-reflct-shopify-app.mp4' style={{width: '100%', height: 'auto'}} />
 
 **Let’s dive into some technical details. How did PlayCanvas help you deliver a smooth experience across desktop and mobile?**
 
@@ -109,7 +109,7 @@ So we first detached every piece of the UI and event listeners, then replaced th
 
 *Willie*: First thing will be some improvements for mobile, just to improve consistency across devices. Then it’s integrations, viewer features, FTUX improvements, and building on our recent update for custom transition animations.
 
-<video autoPlay muted loop controls src='/img/developer-spotlight-reflct-custom-animation.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/developer-spotlight-reflct-custom-animation.mp4' style={{width: '100%', height: 'auto'}} />
 
 **How can the PlayCanvas community try out Reflct or get involved?**
 

--- a/blog/2025-09-17-playcanvas-open-sources-sog-format-for-gaussian-splatting.md
+++ b/blog/2025-09-17-playcanvas-open-sources-sog-format-for-gaussian-splatting.md
@@ -55,7 +55,7 @@ As you might expect, the open source [PlayCanvas Engine](https://github.com/play
 
 Bundled SOG files (`.sog`) are now natively supported in the PlayCanvas Editor! Simply drag and drop a `.sog` file into your ASSETS panel to create a new `gsplat` asset.
 
-<video autoPlay muted loop controls src='/img/editor-sog-import.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/editor-sog-import.mp4' style={{width: '100%', height: 'auto'}} />
 
 Dragging the `gsplat` asset into the viewport triggers the creation of a new `Entity` with the asset assigned to a `GSplatComponent`.
 

--- a/blog/2026-03-11-new-in-supersplat-walk-mode-streamed-lod-and-easy-upload.md
+++ b/blog/2026-03-11-new-in-supersplat-walk-mode-streamed-lod-and-easy-upload.md
@@ -45,11 +45,11 @@ LCC scenes captured on [XGRIDS](https://xgrids.com/) devices already ship with h
 
 Until now, the only way to publish a splat on SuperSplat was through the Editor. Today, we're introducing a brand new **Easy Upload** flow — just hit the **Upload Splat** button on the [SuperSplat](https://superspl.at) homepage, drag and drop a PLY, SOG, Streamed SOG or LCC file and go live in seconds.
 
-<video autoPlay muted loop controls src='/img/supersplat-publishing-easy.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/supersplat-publishing-easy.mp4' style={{width: '100%', height: 'auto'}} />
 
 We've also updated the existing **Editor publishing flow** to share the same new details dialog. When you publish from the [SuperSplat Editor](https://superspl.at/editor), you'll now be redirected to your Manage page to fill in your splat's details while it's being prepared to go live.
 
-<video autoPlay muted loop controls src='/img/supersplat-publishing-editor.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/supersplat-publishing-editor.mp4' style={{width: '100%', height: 'auto'}} />
 
 The new details dialog is just the beginning — expect more fields to appear soon covering license type, capture hardware and software and even geolocation. Stay tuned!
 

--- a/blog/2026-04-16-new-in-supersplat-downloadable-splats-licenses-and-social-links.md
+++ b/blog/2026-04-16-new-in-supersplat-downloadable-splats-licenses-and-social-links.md
@@ -21,11 +21,11 @@ Because it gets your work in front of more people. Downloadable scenes show up i
 
 Want to find downloadable splats? Head to the [Explore](https://superspl.at/?features=downloadable&time=all) page to browse scenes that are available for download.
 
-<video autoPlay muted loop controls src='/img/supersplat-download-splat.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/supersplat-download-splat.mp4' style={{width: '100%', height: 'auto'}} />
 
 Downloaded splats can be used anywhere — in your own apps, research projects or creative tools. A great option is to load them into your **PlayCanvas** projects via the [PlayCanvas Engine](https://github.com/playcanvas/engine) or the [PlayCanvas Editor](https://playcanvas.com).
 
-<video autoPlay muted loop controls src='/img/supersplat-to-playcanvas.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/supersplat-to-playcanvas.mp4' style={{width: '100%', height: 'auto'}} />
 
 ### 📜 Creative Commons Licenses
 
@@ -38,7 +38,7 @@ Sharing your splats is great — but you should be able to decide *how* they're 
 - **CC BY-NC-ND** — Attribution, NonCommercial, No Derivatives
 - **CC BY-NC-SA** — Attribution, NonCommercial, ShareAlike
 
-<video autoPlay muted loop controls src='/img/supersplat-license-picker.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/supersplat-license-picker.mp4' style={{width: '100%', height: 'auto'}} />
 
 The download dialog displays official **CC icons** alongside a ready-to-copy **credit line**, making it easy for anyone who downloads your work to give proper attribution. A **machine-readable license link** is also embedded in the published scene so tools and search engines can pick it up automatically.
 
@@ -46,7 +46,7 @@ The download dialog displays official **CC icons** alongside a ready-to-copy **c
 
 Let the community know who you are. You can now add social links to your profile — **Website**, **X**, **LinkedIn** and **YouTube** — from your [PlayCanvas account settings](https://playcanvas.com/account).
 
-<video autoPlay muted loop controls src='/img/supersplat-social-links.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/supersplat-social-links.mp4' style={{width: '100%', height: 'auto'}} />
 
 Your social icons will appear on your **SuperSplat user page** right alongside your published splats, making it easy for visitors to follow your work across the web.
 

--- a/blog/2026-04-22-turning-a-gaussian-splat-into-a-videogame.md
+++ b/blog/2026-04-22-turning-a-gaussian-splat-into-a-videogame.md
@@ -17,7 +17,7 @@ This post walks through the demo I built to fix all of that:
 * 👉 **[Play it in your browser](https://playcanv.as/p/qxGSuzYq/)** - WASD, mouse to aim, left-click to fire.
 * 👉 **[Check the project](http://playcanvas.com/project/1480299)** - the full PlayCanvas project is public. Every script mentioned in this post lives inside it, ready to read, fork, or remix.
 
-<video autoPlay muted loop controls src='/img/gaussian-splat-fps.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/gaussian-splat-fps.mp4' style={{width: '100%', height: 'auto'}} />
 
 The scene is a gorgeous indoor scan of a real abandoned place by [Christoph Schindelar](https://superspl.at/user?id=schindelar3d). Christoph is one the best artists working with Gaussian Splats out there, so when he proposed to scan a real place for me, I jumped at the opportunity. On top of that splat I bolted a physics collider, a grid of baked lighting probes, a Recast navmesh, eight personality-driven NPCs and a classic FPS loop. Everything runs in a browser tab.
 
@@ -97,7 +97,7 @@ How `Scripts/probes.js` works:
 
 Here's the bake in action - each debug sphere pops in as its cube of faces is rendered and its luminance is averaged. Bright spheres mark a well-lit spot on the floor; dim ones sit in corners and under cover. By the end you can read the scene's lighting as a dotted heatmap before a single byte of JSON is written.
 
-<video autoPlay muted loop controls src='/img/gs-fps-light-probes.mp4' style={{width: '50%', height: 'auto', display: 'block', margin: '0 auto 1.5em'}} />
+<video playsInline autoPlay muted loop controls src='/img/gs-fps-light-probes.mp4' style={{width: '50%', height: 'auto', display: 'block', margin: '0 auto 1.5em'}} />
 
 At runtime, every dynamic character script (weapon, NPC, pickup) loads `lightness.json`, bilinearly samples the grid at its world position, remaps it to a sensible exposure range and calls `meshInstance.setParameter('exposure', value)`. Step from a bright atrium into a dim corridor and your hands darken smoothly. Fire your weapon and the pulsating omni-light bounces off the splat around you.
 

--- a/blog/2026-05-14-new-in-supersplat-software-attribution-collision-generation-and-histogram.md
+++ b/blog/2026-05-14-new-in-supersplat-software-attribution-collision-generation-and-histogram.md
@@ -17,7 +17,7 @@ No two splat creators work quite the same way — our community draws on an ever
 
 Open the **Manage** page for any of your splats and head to the new **Software Used** card. Search the curated catalog — including **Brush**, **Postshot**, **LichtFeld Studio**, **RealityScan**, **KIRI Engine**, **COLMAP**, **Luma**, **Nerfstudio**, **Scaniverse**, **Polycam**, **Agisoft Metashape** and more — and add up to **six** entries. Drag to reorder them. Don't see your favorite tool? Search for it and the picker will offer a quick way to **request** it — or just give us a shout on [Discord](https://discord.com/invite/T3pnhRTTAY).
 
-<video autoPlay muted loop controls src='/img/supersplat-software-attribution.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/supersplat-software-attribution.mp4' style={{width: '100%', height: 'auto'}} />
 
 Once tagged, the software you used appears as a row of **logo chips** on your scene page. **Click any chip** to browse other splats made with the same tool — a great way to find new creators, learn techniques and see how each tool shines in different hands.
 
@@ -27,7 +27,7 @@ Last month we launched **[Walk Mode](/new-in-supersplat-walk-mode-streamed-lod-a
 
 Open your splat in [SuperSplat Studio](https://superspl.at/editor), head to the **Assets** panel and hit **Generate** in the **Collision** section. Three simple presets — **Indoor**, **Outdoor** and **Object** — tune the generation for the kind of scene you have. The algorithm also needs a **seed position** to know where the navigable space begins, and Studio takes that automatically from your **initial camera position** — so as long as you're framing the scene from inside the walkable area, you're good to go.
 
-<video autoPlay muted loop controls src='/img/supersplat-collision-generation.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/supersplat-collision-generation.mp4' style={{width: '100%', height: 'auto'}} />
 
 Browse the [walkable gallery](https://superspl.at/?features=walkable&time=all) to see what the community has been building.
 
@@ -48,7 +48,7 @@ The list of properties you can analyze and select against has grown too. Slice y
 
 New **Visible Splats Only**, **Log Scale** and **All Properties** toggles let you focus the histogram on exactly what you care about.
 
-<video autoPlay muted loop controls src='/img/supersplat-histogram.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/supersplat-histogram.mp4' style={{width: '100%', height: 'auto'}} />
 
 This makes editing huge scenes dramatically faster — isolate the splats you care about with a single drag instead of nudging sliders.
 

--- a/blog/2026-07-09-new-in-supersplat-vibe-code-splat-apps.md
+++ b/blog/2026-07-09-new-in-supersplat-vibe-code-splat-apps.md
@@ -20,7 +20,7 @@ Last month we shipped **[a new WebGPU renderer and automatic streaming](/new-in-
 
 Turning a Gaussian splat into a real, interactive web app used to mean wiring up an engine, a build tool and a viewer by hand. Not any more. Every **downloadable splat** on SuperSplat now comes with a one‑click **starter project** download.
 
-<video autoPlay muted loop controls src='/img/supersplat-vibe-coding.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/supersplat-vibe-coding.mp4' style={{width: '100%', height: 'auto'}} />
 
 Open any downloadable scene, hit **Download** and choose the **Vite project** option. You'll get a complete, ready‑to‑run web app — [PlayCanvas Engine](https://github.com/playcanvas/engine) + [Vite](https://vitejs.dev) + TypeScript — with the splat itself bundled in and the camera pose you set in SuperSplat preserved. Unzip it, run `npm install` and `npm run dev`, and you're looking at your splat running live in the browser.
 
@@ -41,7 +41,7 @@ The whole thing is a small Vite + TypeScript project — [browse the source on G
 
 Today also brings **[SuperSplat Editor 2.29.0](https://github.com/playcanvas/supersplat/releases/tag/v2.29.0)**, and its headline feature is **360° video rendering**. You can now render your animated splat scenes straight to **equirectangular 360° video** — ready to upload to YouTube 360, view in a VR headset or share as immersive social content. Here's how it works:
 
-<video autoPlay muted loop controls src='/img/supersplat-360-video.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/supersplat-360-video.mp4' style={{width: '100%', height: 'auto'}} />
 
 And here's the payoff — a 360° video rendered straight out of SuperSplat and uploaded to YouTube. Open it there and drag to look around, or view it on your phone or in a headset for the full immersive effect:
 
@@ -57,7 +57,7 @@ SuperSplat Editor 2.29.0 also adds export to **SPZ**, the open, compressed splat
 
 With SPZ export, your SuperSplat scenes drop straight into Scaniverse and any other SPZ‑compatible app or pipeline.
 
-<video autoPlay muted loop controls src='/img/supersplat-spz-export.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/supersplat-spz-export.mp4' style={{width: '100%', height: 'auto'}} />
 
 ### ⚡ splat-transform 3.0
 

--- a/blog/2026-07-20-building-the-grace-cathedral-experience.md
+++ b/blog/2026-07-20-building-the-grace-cathedral-experience.md
@@ -62,7 +62,7 @@ Beyond streaming and per-device splat budgets, a few things keep the experience 
 
 While orbiting outside, the Peek toggle carves away the section of wall nearest the camera so you can look inside. A thin, glowing rim outlines the cut edge.
 
-<video autoPlay muted loop controls src='/img/grace-peek.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/grace-peek.mp4' style={{width: '100%', height: 'auto'}} />
 
 It is built on the engine's gsplat shader chunk system, which lets a project replace the `gsplatModifyVS` and `gsplatModifyPS` chunks to modify every splat and every fragment. The cutouts themselves are just box entities in the Editor, grouped under trigger volumes. As the camera moves, the trigger closest to it eases its cutout open while the others ease closed.
 
@@ -76,7 +76,7 @@ The same chunk also animates a flag hidden somewhere in the scene. Splats inside
 
 We created the moving traffic by isolating and duplicating parked cars from the original capture in the SuperSplat Editor:
 
-<video autoPlay muted loop controls src='/img/grace-cars2.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/grace-cars2.mp4' style={{width: '100%', height: 'auto'}} />
 
 Three car splats spawn at randomized intervals and travel past the cathedral at slightly different speeds. They are disabled indoors, returning their splats to the interior's rendering budget.
 
@@ -86,13 +86,13 @@ Three car splats spawn at randomized intervals and travel past the cathedral at 
 
 The exterior orbit controller moves around a rounded-box envelope fitted to the cathedral. Horizontal and vertical motion are parameterized by arc length along the walls, corners and roof, producing uniform camera speed without discontinuities. Zoom adjusts the camera's standoff from the surface, while damped input adds momentum after release.
 
-<video autoPlay muted loop controls src='/img/grace-orbit.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/grace-orbit.mp4' style={{width: '100%', height: 'auto'}} />
 
 #### Camera Flights
 
 Camera flights use authored waypoint graphs to route around the cathedral's architecture. Inside, routing uses the collision mesh to select visible nodes; outside, it tests clearance against the cathedral's orbit envelope. A shortest-path search produces a route that is converted into a cubic spline, interpolating position, orientation, focus distance and field of view. Closing the annotation rewinds the flight to the previous camera state.
 
-<video autoPlay muted loop controls src='/img/grace-fly.mp4' style={{width: '100%', height: 'auto'}} />
+<video playsInline autoPlay muted loop controls src='/img/grace-fly.mp4' style={{width: '100%', height: 'auto'}} />
 
 ### Sound and Other Touches
 


### PR DESCRIPTION
### What changed

Adds the `playsInline` attribute to every `<video>` embed across the blog — 57 tags in 24 posts.

### Why

On iOS Safari, a `<video>` element without `playsinline` is forced into the native fullscreen player the moment it plays. The blog's embeds autoplay (muted), so opening a video-heavy article on iPhone — most recently [Building the Grace Cathedral Experience](https://blog.playcanvas.com/building-the-grace-cathedral-experience) with its four videos — made each video hijack the screen in sequence: dismiss one and the next takes over.

With `playsInline` added, the muted autoplay videos play inline within the page on iOS, matching desktop behavior.

### Notes for reviewers

- Purely mechanical: every `<video ` became `<video playsInline `; no other content touched.
- Verified with a production build — the generated HTML now emits `<video playsinline autoplay muted loop controls ...>`.
- Follow-up idea (not in this PR): a shared `<Video>` MDX component alongside `AppEmbed` would make it impossible to forget this attribute in future posts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)